### PR TITLE
add reparse override

### DIFF
--- a/jobs/README.md
+++ b/jobs/README.md
@@ -73,6 +73,9 @@ This can be done manually by clicking on UI, but if you set this it will be done
 * env varuable : LABEL_STUDIO_PROJECT_BRAZIL = Project ID for the brazil project
 * env variable : API_LABEL_STUDIO_KEY = label studio API key
 
+### To reparse
+* env variable : LABEL_MISINFORMATION_OVERWRITE = Boolean. If activated the job will reparse any extract that has not been included in labelstudio already and add save it to s3.
+
 ## Deployment
 
 App image is pushed on the Scaleway Container Registry, and then deployed on the Scaleway Serverless service.

--- a/jobs/label_misinformation/app/main.py
+++ b/jobs/label_misinformation/app/main.py
@@ -155,7 +155,7 @@ def main(country: Country):
                             bucket=bucket_output,
                             root_folder=bucket_output_folder,
                             country=country,
-                        ):
+                        ) or not bool(os.getenv("LABEL_MISINFORMATION_OVERWRITE", False)):
                             logging.info(
                                 f"Skipping as already saved before: {channel} inside bucket {bucket_output} folder {bucket_output_folder}"
                             )


### PR DESCRIPTION
In order to reparse all data from brazil we need to add an override that allows to reparse data on a certain day, even if the day has already been parsed (and hence objects are present in the s3). Therefore there might be records saved next to the empty.txt file, which makes not a lot of sense but does not harm our system at all. 

As the job checks for what data is already present on labelstudio, any change should be additive, without replacing existing annotations.