### PR TITLE
Deploy belgium francophone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,7 @@ data/processed
 notebooks/experiments/data
 notebooks/experiments/*.csv
 
+climateguard/experiments/logs
+climateguard/experiments/claim_extraction/climateguard_claim_extraction/
 credentials.txt
 

--- a/infrastructure/live/climate/dev/belgium/.env.secrets.dist
+++ b/infrastructure/live/climate/dev/belgium/.env.secrets.dist
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+# Recover these from the country file on vaultwarden
+export TF_VAR_model_name=
+export TF_VAR_labelstudio_project=
+export TF_VAR_labelstudio_project_id=
+export TF_VAR_postgres_password_labelstudio=
+export TF_VAR_labelstudio_admin_password=
+export TF_VAR_labelstudio_user_token=

--- a/infrastructure/live/climate/dev/belgium/.terraform.lock.hcl
+++ b/infrastructure/live/climate/dev/belgium/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/scaleway" {
+  version = "2.70.0"
+  hashes = [
+    "h1:uykjXoa2iZu1HfaiFZ7q0Uk3p7HTEabOPFaAChfhl7M=",
+    "zh:119df819cfe3c46e1ce8fb1b735a68e23a41cbec7d6219821bf697dcc666dfb4",
+    "zh:2366701713fa5b0b69342c8bd5b15794fb735312a76d30eb919a07c82437c273",
+    "zh:3580b4f2ce828bd65248336561eec5ed5c354377ddc751c2de7ff501e54e2fe0",
+    "zh:374e4f7a75a9cb803b3c51bd068995b51910a20dd5d612edf80685447a089b55",
+    "zh:827f94b392d60ce2d54a817073ecf9dc945763a998a5b8dec7375d9c48479d3f",
+    "zh:91c706353391292827d44bbdc4af7d0d719de3a221cc387855203cb0ea43deeb",
+    "zh:ab25815b75c8cd72a0004260e24b2f050eca7c212f18ead2509d3d8bee062fc2",
+    "zh:bfd2083f068c31fdf5eb3af30cb09599d84639ca766ad2d714f67c5e63390d52",
+    "zh:c1df367a3e55ef3e234a7109287c4ff792e05f4171e0ce21fc83ba7832191fd1",
+    "zh:cce694dba2c3fa5574988a149efe6d516e0f81e385e701d2fd7672d24d18a890",
+    "zh:d6249a2a918ba0b105c5040ecdb7230b4ad8bf1da4eb9d74a3587bea7eb9ae99",
+    "zh:ecbfc1ce28921029706caddeb8b950df91e1a00e3abd9d37a87a248e6a2b7c43",
+    "zh:fe50990917cca2e6644c80f0a276f990adf1c4269d6212e6b8b5c7fbc40f8308",
+  ]
+}
+
+provider "registry.opentofu.org/scaleway/scaleway" {
+  version     = "2.70.0"
+  constraints = "~> 2.57"
+  hashes = [
+    "h1:uykjXoa2iZu1HfaiFZ7q0Uk3p7HTEabOPFaAChfhl7M=",
+    "zh:119df819cfe3c46e1ce8fb1b735a68e23a41cbec7d6219821bf697dcc666dfb4",
+    "zh:2366701713fa5b0b69342c8bd5b15794fb735312a76d30eb919a07c82437c273",
+    "zh:3580b4f2ce828bd65248336561eec5ed5c354377ddc751c2de7ff501e54e2fe0",
+    "zh:374e4f7a75a9cb803b3c51bd068995b51910a20dd5d612edf80685447a089b55",
+    "zh:827f94b392d60ce2d54a817073ecf9dc945763a998a5b8dec7375d9c48479d3f",
+    "zh:91c706353391292827d44bbdc4af7d0d719de3a221cc387855203cb0ea43deeb",
+    "zh:ab25815b75c8cd72a0004260e24b2f050eca7c212f18ead2509d3d8bee062fc2",
+    "zh:bfd2083f068c31fdf5eb3af30cb09599d84639ca766ad2d714f67c5e63390d52",
+    "zh:c1df367a3e55ef3e234a7109287c4ff792e05f4171e0ce21fc83ba7832191fd1",
+    "zh:cce694dba2c3fa5574988a149efe6d516e0f81e385e701d2fd7672d24d18a890",
+    "zh:d6249a2a918ba0b105c5040ecdb7230b4ad8bf1da4eb9d74a3587bea7eb9ae99",
+    "zh:ecbfc1ce28921029706caddeb8b950df91e1a00e3abd9d37a87a248e6a2b7c43",
+    "zh:fe50990917cca2e6644c80f0a276f990adf1c4269d6212e6b8b5c7fbc40f8308",
+  ]
+}

--- a/infrastructure/live/climate/dev/belgium/backend.tf
+++ b/infrastructure/live/climate/dev/belgium/backend.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.57"
+    }
+  }
+  backend "s3" {
+    bucket                      = "${var.subject}-safeguards-terraform"
+    key                         = "${var.country}/${var.environment}/terraform.tfstate"
+    endpoint                    = "https://s3.fr-par.scw.cloud"
+    region                      = "fr-par"
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+  }
+}

--- a/infrastructure/live/climate/dev/belgium/main.tf
+++ b/infrastructure/live/climate/dev/belgium/main.tf
@@ -1,0 +1,35 @@
+module "france" {
+  source = "../../../../modules/country"
+  # variables
+  subject                    = var.subject
+  environment                = var.environment
+  country                    = var.country
+  job_cron_schedule          = "47 5 1 1 *" # setting it to run on jan 1st as this is a test env and will launch manually
+  job_cron_schedule_timezone = "Europe/Paris"
+  # Defined as secrets
+  project_secret_access_key     = var.project_secret_access_key
+  project_access_key_id         = var.project_access_key_id
+  project_id                    = var.project_id
+  barometre_pg_instance_name    = var.barometre_pg_instance_name
+  postgres_password_labelstudio = var.postgres_password_labelstudio
+  labelstudio_project           = var.labelstudio_project
+  labelstudio_project_id        = var.labelstudio_project_id
+  labelstudio_admin_password    = var.labelstudio_admin_password
+  labelstudio_user_token        = var.labelstudio_user_token
+  model_name                    = var.model_name
+  sentry_dsn                    = var.sentry_dsn
+}
+
+provider "scaleway" {
+  alias  = "state"
+  region = "fr-par"
+}
+
+provider "scaleway" {
+  alias      = "project"
+  region     = "fr-par"
+  project_id = var.project_id
+  access_key = var.project_access_key_id
+  secret_key = var.project_secret_access_key
+}
+

--- a/infrastructure/live/climate/dev/belgium/terraform.tfvars
+++ b/infrastructure/live/climate/dev/belgium/terraform.tfvars
@@ -1,0 +1,3 @@
+subject     = "climate"
+environment = "dev"
+country     = "belgium"

--- a/infrastructure/live/climate/dev/belgium/variables.tf
+++ b/infrastructure/live/climate/dev/belgium/variables.tf
@@ -1,0 +1,66 @@
+variable "project_secret_access_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "project_access_key_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "project_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "barometre_pg_instance_name" {
+  type    = string
+  default = "rdb-poc"
+}
+
+variable "postgres_password_labelstudio" {
+  type      = string
+  sensitive = true
+}
+
+variable "subject" {
+  type    = string
+  default = "climate"
+}
+
+variable "country" {
+  type    = string
+  default = "france"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+variable "labelstudio_project" {
+  type = number
+}
+
+variable "labelstudio_project_id" {
+  type = number
+}
+
+variable "labelstudio_admin_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "labelstudio_user_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "model_name" {
+  type = string
+}
+
+variable "sentry_dsn" {
+  type      = string
+  sensitive = true
+}

--- a/infrastructure/live/climate/prod/belgium/.env.secrets.dist
+++ b/infrastructure/live/climate/prod/belgium/.env.secrets.dist
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+# Recover these from the country file on vaultwarden
+export TF_VAR_model_name=
+export TF_VAR_labelstudio_project=
+export TF_VAR_labelstudio_project_id=
+export TF_VAR_postgres_password_labelstudio=
+export TF_VAR_labelstudio_admin_password=
+export TF_VAR_labelstudio_user_token=

--- a/infrastructure/live/climate/prod/belgium/.terraform.lock.hcl
+++ b/infrastructure/live/climate/prod/belgium/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/scaleway" {
+  version = "2.70.0"
+  hashes = [
+    "h1:uykjXoa2iZu1HfaiFZ7q0Uk3p7HTEabOPFaAChfhl7M=",
+    "zh:119df819cfe3c46e1ce8fb1b735a68e23a41cbec7d6219821bf697dcc666dfb4",
+    "zh:2366701713fa5b0b69342c8bd5b15794fb735312a76d30eb919a07c82437c273",
+    "zh:3580b4f2ce828bd65248336561eec5ed5c354377ddc751c2de7ff501e54e2fe0",
+    "zh:374e4f7a75a9cb803b3c51bd068995b51910a20dd5d612edf80685447a089b55",
+    "zh:827f94b392d60ce2d54a817073ecf9dc945763a998a5b8dec7375d9c48479d3f",
+    "zh:91c706353391292827d44bbdc4af7d0d719de3a221cc387855203cb0ea43deeb",
+    "zh:ab25815b75c8cd72a0004260e24b2f050eca7c212f18ead2509d3d8bee062fc2",
+    "zh:bfd2083f068c31fdf5eb3af30cb09599d84639ca766ad2d714f67c5e63390d52",
+    "zh:c1df367a3e55ef3e234a7109287c4ff792e05f4171e0ce21fc83ba7832191fd1",
+    "zh:cce694dba2c3fa5574988a149efe6d516e0f81e385e701d2fd7672d24d18a890",
+    "zh:d6249a2a918ba0b105c5040ecdb7230b4ad8bf1da4eb9d74a3587bea7eb9ae99",
+    "zh:ecbfc1ce28921029706caddeb8b950df91e1a00e3abd9d37a87a248e6a2b7c43",
+    "zh:fe50990917cca2e6644c80f0a276f990adf1c4269d6212e6b8b5c7fbc40f8308",
+  ]
+}
+
+provider "registry.opentofu.org/scaleway/scaleway" {
+  version     = "2.70.0"
+  constraints = "~> 2.57"
+  hashes = [
+    "h1:uykjXoa2iZu1HfaiFZ7q0Uk3p7HTEabOPFaAChfhl7M=",
+    "zh:119df819cfe3c46e1ce8fb1b735a68e23a41cbec7d6219821bf697dcc666dfb4",
+    "zh:2366701713fa5b0b69342c8bd5b15794fb735312a76d30eb919a07c82437c273",
+    "zh:3580b4f2ce828bd65248336561eec5ed5c354377ddc751c2de7ff501e54e2fe0",
+    "zh:374e4f7a75a9cb803b3c51bd068995b51910a20dd5d612edf80685447a089b55",
+    "zh:827f94b392d60ce2d54a817073ecf9dc945763a998a5b8dec7375d9c48479d3f",
+    "zh:91c706353391292827d44bbdc4af7d0d719de3a221cc387855203cb0ea43deeb",
+    "zh:ab25815b75c8cd72a0004260e24b2f050eca7c212f18ead2509d3d8bee062fc2",
+    "zh:bfd2083f068c31fdf5eb3af30cb09599d84639ca766ad2d714f67c5e63390d52",
+    "zh:c1df367a3e55ef3e234a7109287c4ff792e05f4171e0ce21fc83ba7832191fd1",
+    "zh:cce694dba2c3fa5574988a149efe6d516e0f81e385e701d2fd7672d24d18a890",
+    "zh:d6249a2a918ba0b105c5040ecdb7230b4ad8bf1da4eb9d74a3587bea7eb9ae99",
+    "zh:ecbfc1ce28921029706caddeb8b950df91e1a00e3abd9d37a87a248e6a2b7c43",
+    "zh:fe50990917cca2e6644c80f0a276f990adf1c4269d6212e6b8b5c7fbc40f8308",
+  ]
+}

--- a/infrastructure/live/climate/prod/belgium/backend.tf
+++ b/infrastructure/live/climate/prod/belgium/backend.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.57"
+    }
+  }
+  backend "s3" {
+    bucket                      = "${var.subject}-safeguards-terraform"
+    key                         = "${var.country}/${var.environment}/terraform.tfstate"
+    endpoint                    = "https://s3.fr-par.scw.cloud"
+    region                      = "fr-par"
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+  }
+}

--- a/infrastructure/live/climate/prod/belgium/main.tf
+++ b/infrastructure/live/climate/prod/belgium/main.tf
@@ -1,0 +1,35 @@
+module "france" {
+  source = "../../../../modules/country"
+  # variables
+  subject                    = var.subject
+  environment                = var.environment
+  country                    = var.country
+  job_cron_schedule          = "47 5 1 1 *" # setting it to run on jan 1st as this is a test env and will launch manually
+  job_cron_schedule_timezone = "Europe/Paris"
+  # Defined as secrets
+  project_secret_access_key     = var.project_secret_access_key
+  project_access_key_id         = var.project_access_key_id
+  project_id                    = var.project_id
+  barometre_pg_instance_name    = var.barometre_pg_instance_name
+  postgres_password_labelstudio = var.postgres_password_labelstudio
+  labelstudio_project           = var.labelstudio_project
+  labelstudio_project_id        = var.labelstudio_project_id
+  labelstudio_admin_password    = var.labelstudio_admin_password
+  labelstudio_user_token        = var.labelstudio_user_token
+  model_name                    = var.model_name
+  sentry_dsn                    = var.sentry_dsn
+}
+
+provider "scaleway" {
+  alias  = "state"
+  region = "fr-par"
+}
+
+provider "scaleway" {
+  alias      = "project"
+  region     = "fr-par"
+  project_id = var.project_id
+  access_key = var.project_access_key_id
+  secret_key = var.project_secret_access_key
+}
+

--- a/infrastructure/live/climate/prod/belgium/terraform.tfvars
+++ b/infrastructure/live/climate/prod/belgium/terraform.tfvars
@@ -1,0 +1,3 @@
+subject     = "climate"
+environment = "dev"
+country     = "belgium"

--- a/infrastructure/live/climate/prod/belgium/variables.tf
+++ b/infrastructure/live/climate/prod/belgium/variables.tf
@@ -1,0 +1,66 @@
+variable "project_secret_access_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "project_access_key_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "project_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "barometre_pg_instance_name" {
+  type    = string
+  default = "rdb-poc"
+}
+
+variable "postgres_password_labelstudio" {
+  type      = string
+  sensitive = true
+}
+
+variable "subject" {
+  type    = string
+  default = "climate"
+}
+
+variable "country" {
+  type    = string
+  default = "france"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+variable "labelstudio_project" {
+  type = number
+}
+
+variable "labelstudio_project_id" {
+  type = number
+}
+
+variable "labelstudio_admin_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "labelstudio_user_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "model_name" {
+  type = string
+}
+
+variable "sentry_dsn" {
+  type      = string
+  sensitive = true
+}

--- a/infrastructure/modules/country/container.tf
+++ b/infrastructure/modules/country/container.tf
@@ -23,7 +23,7 @@ resource "scaleway_container" "labelstudio_container" {
   max_scale      = 1
   memory_limit   = 2048
   cpu_limit      = 1000
-  registry_image = "heartexlabs/label-studio:1.19.0"
+  registry_image = "heartexlabs/label-studio:1.22.0"
   port           = 8080
   deploy         = true
   protocol       = "http1"

--- a/infrastructure/modules/country/job.tf
+++ b/infrastructure/modules/country/job.tf
@@ -2,6 +2,7 @@ resource "scaleway_job_definition" "main" {
   name         = "label-misinformation-${var.country}-${var.environment}"
   cpu_limit    = 4000
   memory_limit = 8192
+  local_storage_capacity = 4096
   image_uri    = "rg.fr-par.scw.cloud/misinformation/label-misinformation:latest"
   timeout      = "60m"
   project_id   = data.scaleway_account_project.project.id

--- a/jobs/label_misinformation/app/country.py
+++ b/jobs/label_misinformation/app/country.py
@@ -19,7 +19,7 @@ class Country:
         field()
     )  # ID for Label Studio project (visible on the web UI url)
     channels: List[str] = field()
-    channels_no_whisper: List[str] = []
+    channels_no_whisper: List[str] = field(default_factory=lambda: [])
 
     def verify_code(self, code: str):
         return code.lower() == self.code

--- a/jobs/label_misinformation/app/country.py
+++ b/jobs/label_misinformation/app/country.py
@@ -19,6 +19,7 @@ class Country:
         field()
     )  # ID for Label Studio project (visible on the web UI url)
     channels: List[str] = field()
+    channels_no_whisper: List[str] = []
 
     def verify_code(self, code: str):
         return code.lower() == self.code
@@ -64,13 +65,55 @@ BELGIUM_COUNTRY = Country(
     code="bel",
     name="belgium",
     language="french",
-    bucket=os.getenv("BUCKET_OUTPUT_BELGIUM", "climateguard-belgium"),
+    bucket=os.getenv("BUCKET_OUTPUT_BELGIUM", "safeguards-climate-belgium-dev"),
     model=get_secret_docker("MODEL_NAME", "gpt-4o-mini"),
     prompt_version=get_secret_docker("PROMPT_VERSION", "0.0.1"),
-    label_studio_id=os.getenv("LABEL_STUDIO_PROJECT_ID_BELGIUM", 12),
-    label_studio_project=os.getenv("LABEL_STUDIO_PROJECT_BELGIUM", 17),
-    channels=["CANALZ", "LAUNE", "LN24", "RTL", "LATROIS"],
+    label_studio_id=os.getenv("LABEL_STUDIO_PROJECT_ID_BELGIUM", 1),
+    label_studio_project=os.getenv("LABEL_STUDIO_PROJECT_BELGIUM", 1),
+    channels=[
+        "CANALZ",
+        "RTL",
+        "LAUNE",
+        "LN24",
+        "LATROIS",
+        "ACTV",
+        "CANALC",
+        "BX1",
+        "CANALZOOM",
+        "MATELE",
+        "NOTELE",
+        "RTC",
+        "TELEMB",
+        "TELESAMBRE",
+        "TVCOM",
+        "TVLUX",
+        "VEDIA",
+        "la-premiere",
+        "bel-rtl",
+        "vivacite",
+        "ln-radio",
+    ],
+    channels_no_whisper=[
+        "CANALZ",
+        "RTL",
+        "LAUNE",
+        "LN24",
+        "LATROIS",
+        "ACTV",
+        "CANALC",
+        "BX1",
+        "CANALZOOM",
+        "MATELE",
+        "NOTELE",
+        "RTC",
+        "TELEMB",
+        "TELESAMBRE",
+        "TVCOM",
+        "TVLUX",
+        "VEDIA",
+    ]
 )
+
 BRAZIL_COUNTRY = Country(
     code="bra",
     name="brazil",
@@ -108,6 +151,7 @@ GERMANY_COUNTRY = Country(
         "prosieben",
         "kabel-eins",
     ],
+    channels_no_whisper=["daserste", "zdf"]
 )
 
 SPAIN_COUNTRY = Country(

--- a/jobs/label_misinformation/app/main.py
+++ b/jobs/label_misinformation/app/main.py
@@ -4,7 +4,7 @@ import sys
 
 import modin.pandas as pd
 import ray
-from country import Country, CountryCollection, get_countries, BELGIUM_COUNTRY
+from country import Country, CountryCollection, get_countries
 from date_utils import get_date_range
 from labelstudio_utils import wait_and_sync_label_studio
 from logging_utils import getLogger
@@ -234,7 +234,7 @@ def main(country: Country):
                             )
 
                             if (
-                                country != BELGIUM_COUNTRY
+                                channel not in country.channels_no_whisper
                             ):  # not from mediatree, so cannot get the new audio
                                 logging.info(
                                     "Getting new plaintext from whisper by getting the original audio..."
@@ -249,10 +249,10 @@ def main(country: Country):
                                 )
                             else:
                                 logging.info(
-                                    "Belgium country - no whispering, keeping the original dataframe"
+                                    f"No mediatree source for {channel}, keeping the original dataframe"
                                 )
                                 # empty string for whisper column
-                                misinformation_only_news[WHISPER_COLUMN_NAME] = ""
+                                misinformation_only_news[WHISPER_COLUMN_NAME] = misinformation_only_news["plaintext"]
 
                                 df_whispered = misinformation_only_news
 

--- a/jobs/label_misinformation/tests/test_country.py
+++ b/jobs/label_misinformation/tests/test_country.py
@@ -61,3 +61,10 @@ def test_get_country_or_collection_from_name():
         ALL_COUNTRIES,
     ):
         assert get_country_or_collection_from_name(entity.name) == entity
+
+
+def test_no_whisper_channels():
+    country = BELGIUM_COUNTRY
+    assert "CANALC" in country.channels_no_whisper
+    country = GERMANY_COUNTRY
+    assert "daserste" in country.channels_no_whisper


### PR DESCRIPTION
Adding the francophone part of belgium. Belgium will be separated into 2 distinct environments:
- `belgium` (french speaking)
- `belgium-flanders` (dutch speaking)

Currently ingesting the following radios from mediatree:
- LN RADIO
- Vivacité
- La Première
- BEL RTL

Plus these channels obtained directly from the CSA:
- RTL
- LAUNE
- ACTV
- CANALC
- BX1
- CANALZOOM
- MATELE
- NOTELE
- RTC
- TELEMB
- TELESAMBRE
- TVCOM
- TVLUX
- VEDIA
